### PR TITLE
fix(desktop): repair electron dev launcher script

### DIFF
--- a/electron/dev.mjs
+++ b/electron/dev.mjs
@@ -1,23 +1,5 @@
 import { spawn } from "node:child_process";
 
-const NPM_BIN = process.platform === "win32" ? "npm.cmd" : "npm";
-
-const electron = spawn(
-	NPM_BIN,
-	[
-		"exec",
-		"--yes",
-		"--package=electron@35.0.1",
-		"electron",
-		"electron/main.cjs",
-	],
-	{
-		stdio: "inherit",
-		env: process.env,
-	},
-);
-
-electron.on("exit", (code) => {
 const STARTUP_TIMEOUT_MS = 120_000;
 const RETRY_INTERVAL_MS = 750;
 const DEV_SERVER_URL = process.env.ELECTRON_DEV_SERVER_URL ?? "http://127.0.0.1:3000";


### PR DESCRIPTION
Fixes electron/dev.mjs so pnpm desktop:dev works as a single command.